### PR TITLE
Log BOOST flow-stability checks with per-condition OK/NO flags and add pressure metric APIs

### DIFF
--- a/lib/core/StateMachine.cpp
+++ b/lib/core/StateMachine.cpp
@@ -323,6 +323,34 @@ void StateMachine::update(float mapLoadPercent,
     }
 
     if (current != lastState) {
+        if (current == SystemState::BOOST && sensors) {
+            float osc = sensors->computeOscillationAmplitude();
+            float rms = sensors->computeRMS();
+            float median = sensors->computeMedianPressure();
+            float mad = sensors->computeMAD();
+            float outlierRatio = sensors->computeOutlierRatio();
+            float rmsSlope = sensors->computeRMSSlope();
+            bool oscOk = (osc <= FLOW_OSCILLATION_KPA_MAX);
+            bool rmsOk = (rms <= FLOW_RMS_KPA_MAX);
+            bool madOk = (mad <= FLOW_MAD_KPA_MAX);
+            bool outlierOk = (outlierRatio <= FLOW_OUTLIER_RATIO_MAX);
+            bool slopeOk = (fabsf(rmsSlope) <= FLOW_RMS_SLOPE_KPA_S_MAX);
+            bool flowStable = oscOk && rmsOk && madOk && outlierOk && slopeOk;
+            Serial.printf(
+                ">> BOOST metrics | osc=%.3f kPa(%s) | rms=%.3f kPa(%s) | median=%.3f kPa | mad=%.3f kPa(%s) | outliers=%.2f(%s) | rms_slope=%.3f kPa/s(%s) | estado_sugerido=%s\n",
+                osc,
+                oscOk ? "OK" : "NO",
+                rms,
+                rmsOk ? "OK" : "NO",
+                median,
+                mad,
+                madOk ? "OK" : "NO",
+                outlierRatio,
+                outlierOk ? "OK" : "NO",
+                rmsSlope,
+                slopeOk ? "OK" : "NO",
+                flowStable ? "FLOW" : "ALIGN");
+        }
         lastState = current;
     }
 }
@@ -479,4 +507,3 @@ void StateMachine::compute_dMAFdt_and_hold(float newestMAFPercent,
     _holdStartMillis = millis();
   }
 }
-

--- a/lib/core/StateMachine.h
+++ b/lib/core/StateMachine.h
@@ -246,6 +246,13 @@ static constexpr uint32_t BEAM_MIN_STREAM_MS = 50u; // tiempo minimo en BEAM ant
   static constexpr float BEAM_VORTEX_RAMP_TAU_FAST_MS = 60.0f;
   static constexpr float BEAM_VORTEX_RAMP_TAU_SLOW_MS = 260.0f;
 
+  // --- Métricas de flujo (para diagnóstico en BOOST, sin cambiar FSM) ---
+  static constexpr float FLOW_OSCILLATION_KPA_MAX = 0.35f;
+  static constexpr float FLOW_RMS_KPA_MAX = 0.25f;
+  static constexpr float FLOW_MAD_KPA_MAX = 0.20f;
+  static constexpr float FLOW_OUTLIER_RATIO_MAX = 0.10f;
+  static constexpr float FLOW_RMS_SLOPE_KPA_S_MAX = 0.08f;
+
   // Seguimiento de la condición BEAM sostenida
   uint32_t _beamCondStartMs = 0;   // instante en que se detecto la condicion por primera vez
   uint32_t _beamStreamStartMs = 0;
@@ -255,6 +262,5 @@ static constexpr uint32_t BEAM_MIN_STREAM_MS = 50u; // tiempo minimo en BEAM ant
   float updateBeamVortexRamp(float mafPower);
 
 };
-
 
 

--- a/lib/sensors/SensorManager.cpp
+++ b/lib/sensors/SensorManager.cpp
@@ -19,6 +19,12 @@ void SensorManager::begin(uint8_t pinPressureData, uint8_t pinPressureSCK, uint8
   for (size_t i = 0; i < PRESSURE_BUFFER_SIZE; i++) pressureKPABuffer[i] = 0.0f;
   bufferIndex = 0;
   pressureCount = 0;
+  pressureMedianKPa = 0.0f;
+  pressureMadKPa = 0.0f;
+  pressureOutlierRatio = 0.0f;
+  pressureRmsSlope = 0.0f;
+  lastPressureRms = 0.0f;
+  lastPressureRmsMs = 0;
 }
 
 
@@ -123,12 +129,16 @@ void SensorManager::updatePressure() {
     // Guardar en buffer
     pressureKPABuffer[bufferIndex++] = pKPa;
     if(bufferIndex >= PRESSURE_BUFFER_SIZE) bufferIndex = 0;
-    if (pressureCount == 0){
+    if (pressureCount < PRESSURE_BUFFER_SIZE) {
       pressureCount++;
     }
 
     // Calcula la amplitud de oscilación en cada ciclo
     amplitudeOscillation = computeOscillationAmplitude();
+    pressureMedianKPa = computeMedianPressure();
+    pressureMadKPa = computeMAD();
+    pressureOutlierRatio = computeOutlierRatio();
+    pressureRmsSlope = computeRMSSlope();
 
 }
 
@@ -152,8 +162,8 @@ float SensorManager::getPressurePercentSigned() {
 }
 
 float SensorManager::getPressurePercentAbs(){
-  float pKPa getPressureKPAFromBuffer();
-  return((fabsf(pKPa)/40.0f)*100.0f)
+  float pKPa = getPressureKPAFromBuffer();
+  return (fabsf(pKPa) / 40.0f) * 100.0f;
 }
 
 // Devuelve la presión del buffer en PSI
@@ -249,3 +259,82 @@ float SensorManager::computeRMS() {
     }
     return sqrt(sumSq / count);
   }
+
+float SensorManager::computeMedianPressure() {
+    const size_t count = pressureCount;
+    if (count == 0) {
+      return 0.0f;
+    }
+    std::vector<float> tmp;
+    tmp.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+      tmp.push_back(pressureKPABuffer[i]);
+    }
+    size_t mid = count / 2;
+    std::nth_element(tmp.begin(), tmp.begin() + mid, tmp.end());
+    float med = tmp[mid];
+    if ((count % 2) == 0) {
+      auto maxIt = std::max_element(tmp.begin(), tmp.begin() + mid);
+      med = (*maxIt + med) * 0.5f;
+    }
+    return med;
+}
+
+float SensorManager::computeMAD() {
+    const size_t count = pressureCount;
+    if (count == 0) {
+      return 0.0f;
+    }
+    float median = computeMedianPressure();
+    std::vector<float> devs;
+    devs.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+      devs.push_back(fabsf(pressureKPABuffer[i] - median));
+    }
+    size_t mid = count / 2;
+    std::nth_element(devs.begin(), devs.begin() + mid, devs.end());
+    float mad = devs[mid];
+    if ((count % 2) == 0) {
+      auto maxIt = std::max_element(devs.begin(), devs.begin() + mid);
+      mad = (*maxIt + mad) * 0.5f;
+    }
+    return mad;
+}
+
+float SensorManager::computeOutlierRatio(float k) {
+    const size_t count = pressureCount;
+    if (count == 0) {
+      return 0.0f;
+    }
+    float median = computeMedianPressure();
+    float mad = computeMAD();
+    if (mad <= 0.0f) {
+      return 0.0f;
+    }
+    float threshold = k * mad;
+    size_t outliers = 0;
+    for (size_t i = 0; i < count; ++i) {
+      if (fabsf(pressureKPABuffer[i] - median) > threshold) {
+        outliers++;
+      }
+    }
+    return static_cast<float>(outliers) / static_cast<float>(count);
+}
+
+float SensorManager::computeRMSSlope() {
+    float rms = computeRMS();
+    uint32_t now = millis();
+    if (lastPressureRmsMs == 0) {
+      lastPressureRms = rms;
+      lastPressureRmsMs = now;
+      return 0.0f;
+    }
+    float dt = (now - lastPressureRmsMs) / 1000.0f;
+    float slope = 0.0f;
+    if (dt > 0.0f) {
+      slope = (rms - lastPressureRms) / dt;
+    }
+    lastPressureRms = rms;
+    lastPressureRmsMs = now;
+    return slope;
+}

--- a/lib/sensors/SensorManager.h
+++ b/lib/sensors/SensorManager.h
@@ -42,6 +42,10 @@ public:
   void  updatePressure();
 
   float computeRMS();
+  float computeMedianPressure();
+  float computeMAD();
+  float computeOutlierRatio(float k = 3.0f);
+  float computeRMSSlope();
   float computeEventRate(float threshold_kPa = 0.5f, float samplingPeriod_ms = 12.5f);
   float computeTau(float threshold_kPa = 0.5f, float samplingPeriod_ms = 12.5f);
 
@@ -52,6 +56,10 @@ public:
   float getPressurePSI();
   float computeOscillationAmplitude();  
   float readOscillationAmplitude(); 
+  float getPressureMedianKPa() const { return pressureMedianKPa; }
+  float getPressureMADKPa() const { return pressureMadKPa; }
+  float getPressureOutlierRatio() const { return pressureOutlierRatio; }
+  float getPressureRMSSlope() const { return pressureRmsSlope; }
 
 
   void updateADS1115(); // 👈 Opcional, si quieres usar una rutina periódica
@@ -87,4 +95,10 @@ private:
   static constexpr size_t PRESSURE_BUFFER_SIZE = 800; // 10 s a 80 Hz
   float pressureKPABuffer[PRESSURE_BUFFER_SIZE];
   size_t bufferIndex = 0;
+  float pressureMedianKPa = 0.0f;
+  float pressureMadKPa = 0.0f;
+  float pressureOutlierRatio = 0.0f;
+  float pressureRmsSlope = 0.0f;
+  float lastPressureRms = 0.0f;
+  uint32_t lastPressureRmsMs = 0;
 };


### PR DESCRIPTION
### Motivation
- Improve BOOST-entry diagnostics so the log shows which individual flow-stability conditions passed or failed, making it easier to decide `FLOW` vs `ALIGN` at a glance.
- Provide sensor-side APIs and cached metrics so the state machine can compute and reuse pressure statistics for diagnostics without duplicating logic.
- Fix small correctness issues in pressure-buffer handling and `getPressurePercentAbs()` formatting to avoid runtime/wrong-value bugs.

### Description
- Add per-condition booleans (`oscOk`, `rmsOk`, `madOk`, `outlierOk`, `slopeOk`) and print `OK/NO` flags alongside each metric in the BOOST-entry `Serial.printf` line, keeping the existing suggested state (`FLOW`/`ALIGN`).
- Introduce flow-threshold constants in `StateMachine.h` (`FLOW_OSCILLATION_KPA_MAX`, `FLOW_RMS_KPA_MAX`, `FLOW_MAD_KPA_MAX`, `FLOW_OUTLIER_RATIO_MAX`, `FLOW_RMS_SLOPE_KPA_S_MAX`).
- Add pressure-statistics APIs to `SensorManager`: `computeMedianPressure()`, `computeMAD()`, `computeOutlierRatio(float k = 3.0f)`, and `computeRMSSlope()`, plus cached fields and getters (`getPressureMedianKPa()`, `getPressureMADKPa()`, `getPressureOutlierRatio()`, `getPressureRMSSlope()`).
- Fix `SensorManager::getPressurePercentAbs()` syntax and adjust `updatePressure()` to correctly increment `pressureCount` only up to the buffer size and refresh cached metrics on update.

### Testing
- No automated tests were executed for these changes.
- The changes were staged and committed locally as `Annotate BOOST metric checks in log` and no test-run was requested or performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a6bb655f08326af73aacdafcaad77)