### PR TITLE
Simplificar control ALIGN ante turbulencia (hotfix)

### DIFF
--- a/lib/core/StateMachine.cpp
+++ b/lib/core/StateMachine.cpp
@@ -330,14 +330,22 @@ void StateMachine::handleActions() {
         }
         power = constrain(power, 0.0f, 1.0f);
 
+        float oscNorm = flowOscillationKPa / FLOW_OSCILLATION_KPA_MAX;
+        float rmsNorm = flowRmsKPa / FLOW_RMS_KPA_MAX;
+        float madNorm = flowMadKPa / FLOW_MAD_KPA_MAX;
+        float outlierNorm = flowOutlierRatio / FLOW_OUTLIER_RATIO_MAX;
+        float slopeNorm = fabsf(flowRmsSlope) / FLOW_RMS_SLOPE_KPA_S_MAX;
+        float turb = max(max(oscNorm, rmsNorm), max(max(madNorm, outlierNorm), slopeNorm));
+
         if (!flowStableNow) {
-            float oscNorm = flowOscillationKPa / FLOW_OSCILLATION_KPA_MAX;
-            float rmsNorm = flowRmsKPa / FLOW_RMS_KPA_MAX;
-            float madNorm = flowMadKPa / FLOW_MAD_KPA_MAX;
-            float outlierNorm = flowOutlierRatio / FLOW_OUTLIER_RATIO_MAX;
-            float slopeNorm = fabsf(flowRmsSlope) / FLOW_RMS_SLOPE_KPA_S_MAX;
-            float turb = max(max(oscNorm, rmsNorm), max(max(madNorm, outlierNorm), slopeNorm));
-            alignAcousticLevel = constrain(alignAcousticLevel + (ALIGN_ACOUSTIC_STEP * turb), 0.0f, ALIGN_ACOUSTIC_MAX);
+            if (turb > 1.0f) {
+                alignAcousticLevel = constrain(alignAcousticLevel - ALIGN_ACOUSTIC_STEP_DOWN,
+                                               0.0f, ALIGN_ACOUSTIC_MAX);
+            } else {
+                float target = max(power, alignAcousticLevel);
+                float up = ALIGN_ACOUSTIC_STEP_UP * (1.0f - constrain(turb, 0.0f, 1.0f));
+                alignAcousticLevel = constrain(target + up, 0.0f, ALIGN_ACOUSTIC_MAX);
+            }
         } else {
             alignAcousticLevel = max(alignAcousticLevel, power);
         }

--- a/lib/core/StateMachine.h
+++ b/lib/core/StateMachine.h
@@ -241,7 +241,8 @@ const float MIN_TAIL_MS = 10.0f;
 
   // --- Comportamiento ALIGN ---
   static constexpr float ALIGN_ACOUSTIC_SEED = 0.02f;
-  static constexpr float ALIGN_ACOUSTIC_STEP = 0.01f;
+  static constexpr float ALIGN_ACOUSTIC_STEP_UP = 0.01f;
+  static constexpr float ALIGN_ACOUSTIC_STEP_DOWN = 0.015f;
   static constexpr float ALIGN_ACOUSTIC_MAX = 1.0f;
   static constexpr float ALIGN_BOOST_SEED = 0.05f;
 


### PR DESCRIPTION
### Motivation
- Aplicar un hotfix rápido para evitar que el estado `ALIGN` incremente ciegamente la potencia acústica cuando empeoran las métricas de turbulencia en lugar de implementar un mapeo MAF→(amplitud,freq) más amplio.
- Reducir la complejidad del seguimiento de histéresis y responder de forma conservadora ante condiciones inestables de flujo.

### Description
- Eliminado el seguimiento de estado de histéresis (`_lastTurbScore`, `_turbTrackingActive`) y la constante de histéresis para simplificar la lógica de respuesta a turbulencia en `ALIGN`.
- Reemplazada la lógica en `StateMachine::handleActions()` para calcular `turb` a partir de las métricas (`flowOscillationKPa`, `flowRmsKPa`, `flowMadKPa`, `flowOutlierRatio`, `flowRmsSlope`) y aplicar una política simple: reducir `alignAcousticLevel` cuando `turb > 1.0` y crecer lentamente con `ALIGN_ACOUSTIC_STEP_UP` en caso contrario, respetando el `power` derivado de `MAF` cuando el flujo está estable.
- Modificados los archivos `lib/core/StateMachine.cpp` y `lib/core/StateMachine.h` para implementar el comportamiento y ajustar las constantes relacionadas con `ALIGN`.

### Testing
- No se ejecutaron pruebas automáticas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982d729c434832695de0b5efcab8792)