### PR TITLE
Add quick 1-minute resonance calibration console command ('C')

### DIFF
--- a/AILCM_Technical_Report.md
+++ b/AILCM_Technical_Report.md
@@ -31,7 +31,43 @@ Potencia transferida:
 ## 3. Geometría y Dimensiones  
 | Elemento               | Dimensión        |  
 | ---------------------- | ---------------- |  
-| Tweeter bala Ø         | 38.1 mm          |  
+
+### 8.1 Calibración rápida de resonancia (≈ 1 minuto)
+**Objetivo:** identificar de forma rápida los rangos de MAF donde la resonancia ofrece mejora, para luego refinar con un mapeo más fino.  
+
+**Comando de consola:** `C` (una sola ejecución inicia todo el barrido).  
+
+**Rango de prueba:** 4.0 kHz a 6.5 kHz.  
+**Resolución rápida (1 min):** 250 Hz por paso → 11 frecuencias (4.0, 4.25, …, 6.5 kHz).  
+**Rampa por frecuencia:** 5 s aprox. (usuario acelera muy lentamente).  
+**Tiempo total estimado:** ~55 s + overhead mínimo de consola.  
+
+#### Flujo por frecuencia (secuencial)
+1. El sistema fija una frecuencia.  
+2. El usuario realiza **una única rampa lenta** de MAF.  
+3. Durante la rampa, el sistema divide el MAF en **bins porcentuales**.  
+4. En cada bin, el sistema ejecuta un pulso corto con amplitudes rotadas: **30% → 50% → 70%** (nunca > 70%).  
+5. Se miden métricas internas y se clasifica el bin:  
+   - **Verde:** mejora fuerte  
+   - **Amarillo:** mejora ligera  
+   - **Rojo:** sin mejora  
+6. Al final de la rampa, se guardan resultados en RAM y se pasa a la siguiente frecuencia.  
+
+#### Resumen final por consola
+Al finalizar todas las frecuencias, se imprime:  
+- Rangos de MAF donde cada frecuencia funcionó mejor.  
+- Amplitud más efectiva por rango.  
+- Zonas donde la resonancia no ayuda.  
+
+#### Instrucciones simples al usuario (texto exacto)
+- “Acelera MUY LENTO”  
+- “Mantén la rampa suave”  
+- “No subas el MAF de golpe”  
+- “Rampa completada”  
+
+#### Restricciones
+- No activar FLOW ni lógica externa.  
+- Proceso rápido y con mínimo esfuerzo del usuario.  
 | Filtro cónico Ø int.   | 88.9 mm          |  
 | Filtro cónico longitud | 101.6 mm         |  
 | Distancia a rotor      | 101.6 mm         |  

--- a/lib/ui/ConsoleUI.cpp
+++ b/lib/ui/ConsoleUI.cpp
@@ -1,5 +1,37 @@
 #include "ConsoleUI.h"
 #include "CalibrationManager.h" 
+#include <math.h>
+
+namespace {
+constexpr float kResonanceFreqStartHz = 4000.0f;
+constexpr float kResonanceFreqEndHz = 6500.0f;
+constexpr float kResonanceFreqStepHz = 250.0f;
+constexpr uint8_t kResonanceFreqCount = 11;
+constexpr uint8_t kResonanceBinCount = 10;
+constexpr float kResonanceBinSizePct = 100.0f / kResonanceBinCount;
+constexpr float kResonanceAmpLevels[3] = {0.3f, 0.5f, 0.7f};
+constexpr uint32_t kRampDurationMs = 5000;
+constexpr uint32_t kBaselineSampleMs = 120;
+constexpr uint32_t kPulseDurationMs = 180;
+constexpr uint32_t kPostSampleMs = 120;
+constexpr float kStrongImproveRatio = 0.15f;
+constexpr float kLightImproveRatio = 0.05f;
+constexpr float kMinBaseline = 0.01f;
+
+float sampleMetric(SensorManager* sensors, uint32_t durationMs) {
+  if (!sensors) return 0.0f;
+  uint32_t start = millis();
+  float sum = 0.0f;
+  uint16_t count = 0;
+  while (millis() - start < durationMs) {
+    sum += sensors->computeOscillationAmplitude();
+    count++;
+    delay(10);
+  }
+  return count > 0 ? (sum / count) : 0.0f;
+}
+
+} // namespace
 
 void ConsoleUI::begin() {
 }
@@ -125,6 +157,10 @@ void ConsoleUI::interpretarComando(char c) {
     case 'c':  // Solicitar calibración por consola
       consoleCalibRequested = true;
       this->println(">> Solicitud de calibración registrada.");
+      break;
+
+    case 'C':  // Calibración rápida de resonancia (1 min aprox)
+      runResonanceCalibration();
       break;
 
     case 'd':  // Activar modo desarrollador
@@ -509,6 +545,7 @@ void ConsoleUI::imprimirHelp() {
   this->println(F("\n📘 Comandos disponibles:"));
   this->println(F("  a  → Activar/Desactivar sistema completo (seguridad/falla)"));
   this->println(F("  c  → Ejecutar rutina de calibración de sensores"));
+  this->println(F("  C  → Calibración rápida de resonancia (1 minuto)"));
   this->println(F("  d  → Activar modo desarrollador"));
   this->println(F("  m  → Mostrar menú de comandos"));
   this->println(F("  s  → Activar/Desactivar dashboard del sistema"));
@@ -523,6 +560,155 @@ void ConsoleUI::imprimirHelp() {
     this->println(F("  v  → Visualizar curva MAF-MAP (pendiente desarrollo)"));
     this->println(F("  x  → Paro manual, volver a IDLE"));
     this->println(F("  z  → Activar/Desactivar modo simulación"));
+  }
+}
+
+void ConsoleUI::runResonanceCalibration() {
+  if (!sensors || !actuators) {
+    this->println("⚠️ No se puede iniciar calibración: faltan sensores o actuadores.");
+    return;
+  }
+
+  bool prevSistema = sistemaActivo;
+  bool prevDashboard = dashboardEnabled;
+  bool prevMirrorSistema = mirror ? mirror->sistemaActivo : false;
+  bool prevMirrorDashboard = mirror ? mirror->dashboardEnabled : false;
+
+  sistemaActivo = false;
+  dashboardEnabled = false;
+  if (mirror) {
+    mirror->sistemaActivo = false;
+    mirror->dashboardEnabled = false;
+  }
+
+  actuators->stopAll();
+
+  this->println("\n=== Calibración rápida de resonancia ===");
+  this->println("Acelera MUY LENTO");
+  this->println("Mantén la rampa suave");
+  this->println("No subas el MAF de golpe");
+
+  resonanceResultsValid = false;
+
+  for (uint8_t freqIndex = 0; freqIndex < kResonanceFreqCount; ++freqIndex) {
+    float freqHz = kResonanceFreqStartHz + kResonanceFreqStepHz * freqIndex;
+    if (freqHz > kResonanceFreqEndHz + 0.1f) {
+      break;
+    }
+
+    resonanceResults[freqIndex].freqHz = freqHz;
+    for (uint8_t bin = 0; bin < kResonanceBinCount; ++bin) {
+      resonanceResults[freqIndex].bins[bin] = {};
+    }
+
+    this->printf("\n>> Frecuencia %.0f Hz | Rampa ~%lu ms\n", freqHz, (unsigned long)kRampDurationMs);
+
+    unsigned long rampStart = millis();
+    while (millis() - rampStart < kRampDurationMs) {
+      float mafPct = sensors->readMAFLoadPercent();
+      if (mafPct < 0.0f) mafPct = 0.0f;
+      if (mafPct > 100.0f) mafPct = 100.0f;
+
+      uint8_t binIndex = static_cast<uint8_t>(mafPct / kResonanceBinSizePct);
+      if (binIndex >= kResonanceBinCount) {
+        binIndex = kResonanceBinCount - 1;
+      }
+
+      ResonanceBinResult& bin = resonanceResults[freqIndex].bins[binIndex];
+      if (!bin.measured) {
+        float baseline = sampleMetric(sensors, kBaselineSampleMs);
+        float amplitude = kResonanceAmpLevels[binIndex % 3];
+
+        actuators->startISRSine(static_cast<uint32_t>(freqHz), amplitude);
+        delay(kPulseDurationMs);
+        actuators->stopISRSine();
+        delay(20);
+
+        float after = sampleMetric(sensors, kPostSampleMs);
+        float denom = fabsf(baseline);
+        if (denom < kMinBaseline) denom = kMinBaseline;
+        float ratio = (after - baseline) / denom;
+
+        ResonanceGrade grade = ResonanceGrade::NONE;
+        if (ratio >= kStrongImproveRatio) {
+          grade = ResonanceGrade::STRONG;
+        } else if (ratio >= kLightImproveRatio) {
+          grade = ResonanceGrade::LIGHT;
+        }
+
+        bin.grade = grade;
+        bin.amplitude = amplitude;
+        bin.improvement = ratio;
+        bin.measured = true;
+
+        uint8_t binStart = static_cast<uint8_t>(binIndex * kResonanceBinSizePct);
+        uint8_t binEnd = static_cast<uint8_t>((binIndex + 1) * kResonanceBinSizePct);
+        const char* gradeText = (grade == ResonanceGrade::STRONG) ? "VERDE"
+                               : (grade == ResonanceGrade::LIGHT) ? "AMARILLO"
+                               : "ROJO";
+        this->printf("Bin %u (%u-%u%%) amp %.0f%% -> %s\n",
+                     binIndex + 1,
+                     binStart,
+                     binEnd,
+                     amplitude * 100.0f,
+                     gradeText);
+      }
+
+      delay(20);
+    }
+
+    this->println("Rampa completada");
+  }
+
+  resonanceResultsValid = true;
+
+  this->println("\n=== Resumen de resonancia ===");
+  for (uint8_t freqIndex = 0; freqIndex < kResonanceFreqCount; ++freqIndex) {
+    float freqHz = resonanceResults[freqIndex].freqHz;
+    if (freqHz <= 0.0f) continue;
+
+    this->printf("\nFrecuencia %.0f Hz:\n", freqHz);
+    this->println("  Mejores rangos (MAF):");
+    bool anyImprovement = false;
+    for (uint8_t binIndex = 0; binIndex < kResonanceBinCount; ++binIndex) {
+      const ResonanceBinResult& bin = resonanceResults[freqIndex].bins[binIndex];
+      if (!bin.measured) continue;
+      if (bin.grade == ResonanceGrade::NONE) continue;
+
+      uint8_t binStart = static_cast<uint8_t>(binIndex * kResonanceBinSizePct);
+      uint8_t binEnd = static_cast<uint8_t>((binIndex + 1) * kResonanceBinSizePct);
+      const char* gradeText = (bin.grade == ResonanceGrade::STRONG) ? "VERDE" : "AMARILLO";
+      this->printf("    %u-%u%% | amp %.0f%% | %s\n",
+                   binStart, binEnd, bin.amplitude * 100.0f, gradeText);
+      anyImprovement = true;
+    }
+    if (!anyImprovement) {
+      this->println("    (sin mejora detectada)");
+    }
+
+    this->println("  Zonas donde no ayuda:");
+    bool anyNoHelp = false;
+    for (uint8_t binIndex = 0; binIndex < kResonanceBinCount; ++binIndex) {
+      const ResonanceBinResult& bin = resonanceResults[freqIndex].bins[binIndex];
+      if (!bin.measured) continue;
+      if (bin.grade != ResonanceGrade::NONE) continue;
+      uint8_t binStart = static_cast<uint8_t>(binIndex * kResonanceBinSizePct);
+      uint8_t binEnd = static_cast<uint8_t>((binIndex + 1) * kResonanceBinSizePct);
+      this->printf("    %u-%u%%\n", binStart, binEnd);
+      anyNoHelp = true;
+    }
+    if (!anyNoHelp) {
+      this->println("    (sin datos)");
+    }
+  }
+
+  actuators->stopAll();
+
+  sistemaActivo = prevSistema;
+  dashboardEnabled = prevDashboard;
+  if (mirror) {
+    mirror->sistemaActivo = prevMirrorSistema;
+    mirror->dashboardEnabled = prevMirrorDashboard;
   }
 }
 

--- a/lib/ui/ConsoleUI.h
+++ b/lib/ui/ConsoleUI.h
@@ -31,6 +31,7 @@ public:
   }
 
   virtual bool isDeveloperMode() const;
+  void runResonanceCalibration();
 protected:
   bool sistemaActivo = true;
   StateMachine*      fsm = nullptr;
@@ -47,6 +48,27 @@ protected:
   Logger* logger = nullptr;
 
   SystemState lastState = SystemState::OFF;
+
+  enum class ResonanceGrade : uint8_t {
+    NONE = 0,
+    LIGHT = 1,
+    STRONG = 2
+  };
+
+  struct ResonanceBinResult {
+    ResonanceGrade grade = ResonanceGrade::NONE;
+    float amplitude = 0.0f; // 0..1
+    float improvement = 0.0f; // ratio
+    bool measured = false;
+  };
+
+  struct ResonanceFrequencyResult {
+    float freqHz = 0.0f;
+    ResonanceBinResult bins[10];
+  };
+
+  bool resonanceResultsValid = false;
+  ResonanceFrequencyResult resonanceResults[11];
 
   
 


### PR DESCRIPTION
### Motivation
- Provide a fast (~1 minute) resonance calibration that identifies coarse MAF ranges where acoustic injection improves oscillation, enabling later finer mapping.

### Description
- Add `runResonanceCalibration()` to `ConsoleUI` and expose it as the console command `C` with a help entry. 
- Implement the quick calibration flow in `lib/ui/ConsoleUI.cpp`: sweep 4.0 kHz → 6.5 kHz in 250 Hz steps (11 frequencies) with ~5 s per-frequency ramp, bin MAF into 10 percentage bins and emit short ISR sine pulses rotating amplitudes (30% → 50% → 70%) per bin. 
- Classify bins by measured improvement ratio (VERDE/AMARILLO/ROJO), store results in RAM structures (`ResonanceFrequencyResult` / `ResonanceBinResult`) for session reporting, and print a final summary per frequency. 
- Temporarily disable dashboard and system activity and stop actuators during the routine, then restore previous UI/actuator state on completion.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e09013c8832690560d3482b73b28)