### PR TITLE
Harden resonance mapping with repeated samples and confirmation

### DIFF
--- a/lib/core/ResonanceCalibrationService.cpp
+++ b/lib/core/ResonanceCalibrationService.cpp
@@ -1,19 +1,41 @@
 #include "ResonanceCalibrationService.h"
 #include <math.h>
 
+namespace {
+void sortSmall(float* values, uint8_t count) {
+  for (uint8_t i = 0; i + 1 < count; ++i) {
+    uint8_t minIdx = i;
+    for (uint8_t j = i + 1; j < count; ++j) {
+      if (values[j] < values[minIdx]) {
+        minIdx = j;
+      }
+    }
+    if (minIdx != i) {
+      float tmp = values[i];
+      values[i] = values[minIdx];
+      values[minIdx] = tmp;
+    }
+  }
+}
+}  // namespace
+
 float ResonanceCalibrationService::sampleMetric(SensorManager& sensors,
                                               ResonanceCalibrationReporter& reporter,
                                               float freqHz,
                                               float amplitude,
                                               uint32_t durationMs,
                                               const char* phase) const {
+  // Aísla cada medición (baseline/test) para evitar arrastrar historial
+  // de bins o corridas anteriores.
+  sensors.resetPressureMetrics();
+
   const uint32_t start = millis();
   uint32_t lastPrintMs = 0;
   float sum = 0.0f;
   uint16_t count = 0;
 
   while (millis() - start < durationMs) {
-    const float metric = sensors.computeOscillationAmplitude();
+    const float metric = sensors.computeOscillationAmplitudeWindow(durationMs);
     sum += metric;
     ++count;
 
@@ -50,10 +72,162 @@ float ResonanceCalibrationService::measureWithStreaming(SensorManager& sensors,
 
 uint32_t ResonanceCalibrationService::estimateBinTestTimeMs() const {
   const uint32_t perFreqMs = kFreqWarmupMs +
-                             kLevelSettleMs + kBaselineSampleMs +
-                             (3 * (kLevelSettleMs + kBinSampleMs)) +
+                             (kRepeatCount * (kLevelSettleMs + kBaselineSampleMs)) +
+                             (kAmpCount * kRepeatCount * (kLevelSettleMs + kBinSampleMs)) +
                              kFreqCooldownMs;
-  return perFreqMs * kFreqCount;
+
+  const uint32_t confirmMs = kFreqWarmupMs +
+                             (kConfirmRepeatCount * (kLevelSettleMs + kBaselineSampleMs)) +
+                             (kConfirmRepeatCount * (kLevelSettleMs + kBinSampleMs)) +
+                             kFreqCooldownMs;
+
+  return (perFreqMs * kFreqCount) + confirmMs;
+}
+
+bool ResonanceCalibrationService::ensureStableInBin(SensorManager& sensors,
+                                                    ResonanceCalibrationReporter& reporter,
+                                                    uint8_t binIndex) const {
+  const float binStart = kMafMapMinPct + (float(binIndex) * kBinSizePct);
+  const float binEnd = kMafMapMinPct + (float(binIndex + 1) * kBinSizePct);
+  const float stableMin = binStart + kBinStabilityTolPct;
+  const float stableMax = binEnd - kBinStabilityTolPct;
+
+  if (stableMax <= stableMin) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  uint32_t stableSince = 0;
+  uint32_t lastMsgMs = 0;
+
+  while (millis() - start < 6000) {
+    float mafPct = sensors.readMAFLoadPercent();
+    if (mafPct < 0.0f) mafPct = 0.0f;
+    if (mafPct > 100.0f) mafPct = 100.0f;
+
+    const bool inStableBand = (mafPct >= stableMin && mafPct <= stableMax);
+    if (inStableBand) {
+      if (stableSince == 0) stableSince = millis();
+      if ((millis() - stableSince) >= kBinStabilityHoldMs) {
+        return true;
+      }
+    } else {
+      stableSince = 0;
+      const uint32_t now = millis();
+      if (now - lastMsgMs > 1000) {
+        lastMsgMs = now;
+        reporter.println("[MAPEO] Ajusta pedal para estabilizar bin " + String(binIndex + 1) +
+                         " (" + String((int)binStart) + "-" + String((int)binEnd) +
+                         "%). MAF=" + String(mafPct, 1) + "%");
+      }
+    }
+    delay(25);
+  }
+
+  reporter.println("[MAPEO] Aviso: no se estabilizó totalmente el bin " + String(binIndex + 1) +
+                   ", se continúa con la medición");
+  return false;
+}
+
+bool ResonanceCalibrationService::waitForMafRiseAfterBaseline(SensorManager& sensors,
+                                                              ResonanceCalibrationReporter& reporter,
+                                                              uint8_t binIndex,
+                                                              float baselineMafPct) const {
+  const float binStart = kMafMapMinPct + (float(binIndex) * kBinSizePct);
+  const float binEnd = kMafMapMinPct + (float(binIndex + 1) * kBinSizePct);
+  float targetMaf = baselineMafPct + kMafPostBaselineRisePct;
+  if (targetMaf > binEnd) {
+    targetMaf = binEnd;
+  }
+
+  uint32_t lastMsgMs = 0;
+  while (true) {
+    float mafPct = sensors.readMAFLoadPercent();
+    if (mafPct < 0.0f) mafPct = 0.0f;
+    if (mafPct > 100.0f) mafPct = 100.0f;
+
+    const bool insideBin = (mafPct >= binStart && mafPct <= binEnd);
+    if (insideBin && mafPct >= targetMaf) {
+      return true;
+    }
+
+    const uint32_t now = millis();
+    if (now - lastMsgMs > 1000) {
+      lastMsgMs = now;
+      reporter.println("[MAPEO] Esperando subida de MAF tras baseline en bin " + String(binIndex + 1) +
+                       ": baseline=" + String(baselineMafPct, 1) + "% -> objetivo=" +
+                       String(targetMaf, 1) + "% | actual=" + String(mafPct, 1) + "%");
+      reporter.println("Acelera suavemente para continuar pruebas");
+    }
+    delay(40);
+  }
+}
+
+ResonanceCalibrationService::RepeatStats ResonanceCalibrationService::measureMedianWithRepeats(
+    SensorManager& sensors,
+    ActuatorManager& actuators,
+    ResonanceCalibrationReporter& reporter,
+    float freqHz,
+    float amplitude,
+    uint32_t durationMs,
+    const char* phase,
+    uint8_t binIndex,
+    uint8_t repeats) const {
+  if (repeats == 0) {
+    return {};
+  }
+
+  float values[5] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+  const uint8_t cappedRepeats = repeats > 5 ? 5 : repeats;
+
+  for (uint8_t r = 0; r < cappedRepeats; ++r) {
+    ensureStableInBin(sensors, reporter, binIndex);
+    values[r] = measureWithStreaming(sensors, actuators, reporter, freqHz, amplitude, durationMs, phase);
+  }
+
+  sortSmall(values, cappedRepeats);
+
+  RepeatStats stats;
+  stats.min = values[0];
+  stats.max = values[cappedRepeats - 1];
+  stats.median = values[cappedRepeats / 2];
+  return stats;
+}
+
+bool ResonanceCalibrationService::confirmBestCandidateInBin(SensorManager& sensors,
+                                                            ActuatorManager& actuators,
+                                                            ResonanceCalibrationReporter& reporter,
+                                                            uint8_t binIndex,
+                                                            uint8_t bestFreqIdx) const {
+  const float freqHz = results[bestFreqIdx].freqHz;
+  const BinResult& bestBin = results[bestFreqIdx].bins[binIndex];
+
+  actuators.startISRSine(static_cast<uint32_t>(freqHz), 0.0f);
+  delay(kFreqWarmupMs);
+
+  const RepeatStats baselineStats = measureMedianWithRepeats(
+      sensors, actuators, reporter, freqHz, 0.0f, kBaselineSampleMs, " confirm-baseline", binIndex,
+      kConfirmRepeatCount);
+
+  float baselineMafPct = sensors.readMAFLoadPercent();
+  if (baselineMafPct < 0.0f) baselineMafPct = 0.0f;
+  if (baselineMafPct > 100.0f) baselineMafPct = 100.0f;
+  waitForMafRiseAfterBaseline(sensors, reporter, binIndex, baselineMafPct);
+
+  const RepeatStats testStats = measureMedianWithRepeats(
+      sensors, actuators, reporter, freqHz, bestBin.amplitude, kBinSampleMs, " confirm-test", binIndex,
+      kConfirmRepeatCount);
+
+  actuators.stopISRSine();
+  delay(kFreqCooldownMs);
+
+  float denom = fabsf(baselineStats.median);
+  if (denom < kMinBaseline) denom = kMinBaseline;
+  const float confirmRatio = (testStats.median - baselineStats.median) / denom;
+
+  reporter.println("[MAPEO] Confirmación bin " + String(binIndex + 1) +
+                   " | ratio=" + String(confirmRatio * 100.0f, 1) + "%");
+  return confirmRatio >= kLightImproveRatio;
 }
 
 bool ResonanceCalibrationService::waitForBinEntry(SensorManager& sensors,
@@ -120,11 +294,17 @@ String ResonanceCalibrationService::formatBinLine(uint8_t binIndex,
 
 uint8_t ResonanceCalibrationService::findBestFreqForBin(uint8_t binIndex) const {
   uint8_t bestFreq = 0;
+  Grade bestGrade = Grade::NONE;
   float bestImprovement = -9999.0f;
   for (uint8_t freqIndex = 0; freqIndex < kFreqCount; ++freqIndex) {
     const BinResult& b = results[freqIndex].bins[binIndex];
     if (!b.measured) continue;
-    if (b.improvement > bestImprovement) {
+    const bool betterGrade = static_cast<uint8_t>(b.grade) > static_cast<uint8_t>(bestGrade);
+    const bool sameGradeBetterRatio =
+        (static_cast<uint8_t>(b.grade) == static_cast<uint8_t>(bestGrade) &&
+         b.improvement > bestImprovement);
+    if (betterGrade || sameGradeBetterRatio) {
+      bestGrade = b.grade;
       bestImprovement = b.improvement;
       bestFreq = freqIndex;
     }
@@ -146,6 +326,8 @@ bool ResonanceCalibrationService::run(SensorManager& sensors,
   reporter.println("Se prueban 3 frecuencias dentro de CADA bin de MAF.");
   reporter.println("Mapeo de bins limitado a " + String(kMafMapMinPct, 0) + "-" +
                    String(kMafMapMaxPct, 0) + "% de MAF.");
+  reporter.println("Amplitud acústica de prueba: 30-100%");
+  reporter.println("Avance post-baseline: requiere +" + String(kMafPostBaselineRisePct, 1) + "% MAF");
   reporter.println("Acelera MUY LENTO");
   reporter.println("Mantén la rampa suave");
   reporter.println("No subas el MAF de golpe");
@@ -169,20 +351,39 @@ bool ResonanceCalibrationService::run(SensorManager& sensors,
       actuators.startISRSine(static_cast<uint32_t>(freqHz), 0.0f);
       delay(kFreqWarmupMs);
 
-      const float baseline = measureWithStreaming(sensors, actuators, reporter, freqHz, 0.0f, kBaselineSampleMs, " baseline");
+      const RepeatStats baselineStats = measureMedianWithRepeats(
+          sensors, actuators, reporter, freqHz, 0.0f, kBaselineSampleMs, " baseline", binIndex,
+          kRepeatCount);
+      const float baseline = baselineStats.median;
+      float baselineMafPct = sensors.readMAFLoadPercent();
+      if (baselineMafPct < 0.0f) baselineMafPct = 0.0f;
+      if (baselineMafPct > 100.0f) baselineMafPct = 100.0f;
+      waitForMafRiseAfterBaseline(sensors, reporter, binIndex, baselineMafPct);
 
       Grade bestGrade = Grade::NONE;
       float bestAmp = kAmpLevels[0];
       float bestRatio = -9999.0f;
 
-      for (uint8_t ampIndex = 0; ampIndex < 3; ++ampIndex) {
+      for (uint8_t ampIndex = 0; ampIndex < kAmpCount; ++ampIndex) {
         const float amp = kAmpLevels[ampIndex];
         reporter.println("[INJ] freq=" + String(freqHz, 0) + " Hz | level=" + String(amp * 100.0f, 0) + "%");
 
-        const float measured = measureWithStreaming(sensors, actuators, reporter, freqHz, amp, kBinSampleMs, " test");
+        const RepeatStats testStats = measureMedianWithRepeats(
+            sensors, actuators, reporter, freqHz, amp, kBinSampleMs, " test", binIndex, kRepeatCount);
+        const float measured = testStats.median;
         float denom = fabsf(baseline);
         if (denom < kMinBaseline) denom = kMinBaseline;
-        const float ratio = (measured - baseline) / denom;
+        const float rawRatio = (measured - baseline) / denom;
+
+        float spreadDenom = fabsf(measured);
+        if (spreadDenom < kMinBaseline) spreadDenom = kMinBaseline;
+        const float spreadRatio = (testStats.max - testStats.min) / spreadDenom;
+        const float ratio = rawRatio - (kRepeatSpreadPenalty * spreadRatio);
+
+        reporter.println("[INJ] rep-med=" + String(measured, 3) +
+                         " | spread=" + String((testStats.max - testStats.min), 3) +
+                         " | raw=" + String(rawRatio * 100.0f, 1) + "% | adj=" +
+                         String(ratio * 100.0f, 1) + "%");
 
         Grade grade = Grade::NONE;
         if (ratio >= kStrongImproveRatio) {
@@ -210,7 +411,16 @@ bool ResonanceCalibrationService::run(SensorManager& sensors,
     }
 
     const uint8_t bestFreqIdx = findBestFreqForBin(binIndex);
-    const BinResult& bestBin = results[bestFreqIdx].bins[binIndex];
+    BinResult& bestBin = results[bestFreqIdx].bins[binIndex];
+
+    const bool confirmed = confirmBestCandidateInBin(sensors, actuators, reporter, binIndex, bestFreqIdx);
+    if (!confirmed && bestBin.grade != Grade::NONE) {
+      reporter.println("[MAPEO] Confirmación fallida en bin " + String(binIndex + 1) +
+                       ": se degrada a ROJO");
+      bestBin.grade = Grade::NONE;
+      bestBin.improvement = 0.0f;
+    }
+
     reporter.println("[MAPEO] Mejor para bin " + String(binIndex + 1) + ": " +
                      String(results[bestFreqIdx].freqHz, 0) + " Hz | amp " +
                      String(bestBin.amplitude * 100.0f, 0) + "% | " + gradeText(bestBin.grade));

--- a/lib/core/ResonanceCalibrationService.h
+++ b/lib/core/ResonanceCalibrationService.h
@@ -41,24 +41,37 @@ public:
 
 private:
   static constexpr float kFreqListHz[kFreqCount] = {5000.0f, 5250.0f, 5500.0f};
-  static constexpr uint8_t kBinCount = 3;
+  static constexpr uint8_t kBinCount = 6;
   static constexpr float kMafMapMinPct = 20.0f;
   static constexpr float kMafMapMaxPct = 40.0f;
   static constexpr float kBinSizePct = (kMafMapMaxPct - kMafMapMinPct) / kBinCount;
-  static constexpr float kAmpLevels[3] = {0.3f, 0.5f, 0.7f};
+  static constexpr uint8_t kAmpCount = 4;
+  static constexpr float kAmpLevels[kAmpCount] = {0.3f, 0.5f, 0.7f, 1.0f};
   static constexpr uint32_t kFreqWarmupMs = 80;
   static constexpr uint32_t kLevelSettleMs = 120;
-  static constexpr uint32_t kBaselineSampleMs = 280;
-  static constexpr uint32_t kBinSampleMs = 260;
+  static constexpr uint32_t kBaselineSampleMs = 420;
+  static constexpr uint32_t kBinSampleMs = 420;
   static constexpr uint32_t kFreqCooldownMs = 20;
+  static constexpr uint32_t kBinStabilityHoldMs = 260;
+  static constexpr float kBinStabilityTolPct = 0.9f;
+  static constexpr uint8_t kRepeatCount = 3;
+  static constexpr float kRepeatSpreadPenalty = 0.20f;
+  static constexpr uint8_t kConfirmRepeatCount = 2;
   static constexpr float kStrongImproveRatio = 0.15f;
   static constexpr float kLightImproveRatio = 0.05f;
   static constexpr float kMinBaseline = 0.01f;
   static constexpr float kMafRiseEpsPct = 0.25f;
+  static constexpr float kMafPostBaselineRisePct = 0.8f;
   static constexpr uint32_t kLivePrintPeriodMs = 120;
 
   bool resultsValid = false;
   FrequencyResult results[kFreqCount];
+
+  struct RepeatStats {
+    float median = 0.0f;
+    float min = 0.0f;
+    float max = 0.0f;
+  };
 
   float sampleMetric(SensorManager& sensors,
                      ResonanceCalibrationReporter& reporter,
@@ -78,6 +91,27 @@ private:
                        ResonanceCalibrationReporter& reporter,
                        uint8_t binIndex,
                        float& lastAcceptedMaf) const;
+  bool ensureStableInBin(SensorManager& sensors,
+                         ResonanceCalibrationReporter& reporter,
+                         uint8_t binIndex) const;
+  bool waitForMafRiseAfterBaseline(SensorManager& sensors,
+                                   ResonanceCalibrationReporter& reporter,
+                                   uint8_t binIndex,
+                                   float baselineMafPct) const;
+  RepeatStats measureMedianWithRepeats(SensorManager& sensors,
+                                       ActuatorManager& actuators,
+                                       ResonanceCalibrationReporter& reporter,
+                                       float freqHz,
+                                       float amplitude,
+                                       uint32_t durationMs,
+                                       const char* phase,
+                                       uint8_t binIndex,
+                                       uint8_t repeats) const;
+  bool confirmBestCandidateInBin(SensorManager& sensors,
+                                 ActuatorManager& actuators,
+                                 ResonanceCalibrationReporter& reporter,
+                                 uint8_t binIndex,
+                                 uint8_t bestFreqIdx) const;
   static const char* gradeText(Grade grade);
   String formatBinLine(uint8_t binIndex, float freq, float amp, Grade grade, float ratio) const;
   uint8_t findBestFreqForBin(uint8_t binIndex) const;

--- a/lib/sensors/SensorManager.cpp
+++ b/lib/sensors/SensorManager.cpp
@@ -17,14 +17,7 @@ void SensorManager::begin(uint8_t pinPressureData, uint8_t pinPressureSCK, uint8
   pressureSensor.begin(pinPressureData, pinPressureSCK);
       // Inicializar buffer
   for (size_t i = 0; i < PRESSURE_BUFFER_SIZE; i++) pressureKPABuffer[i] = 0.0f;
-  bufferIndex = 0;
-  pressureCount = 0;
-  pressureMedianKPa = 0.0f;
-  pressureMadKPa = 0.0f;
-  pressureOutlierRatio = 0.0f;
-  pressureRmsSlope = 0.0f;
-  lastPressureRms = 0.0f;
-  lastPressureRmsMs = 0;
+  resetPressureMetrics();
 }
 
 
@@ -194,8 +187,53 @@ float SensorManager::computeOscillationAmplitude() {
     return (highVal > lowVal) ? (highVal - lowVal) : 0.0f;
 }
 
+float SensorManager::computeOscillationAmplitudeWindow(uint32_t windowMs, float samplePeriodMs) const {
+    if (pressureCount == 0) {
+      return 0.0f;
+    }
+
+    const size_t maxSamples = static_cast<size_t>(windowMs / samplePeriodMs);
+    size_t n = pressureCount;
+    if (maxSamples > 0 && maxSamples < n) {
+      n = maxSamples;
+    }
+
+    std::vector<float> tmp;
+    tmp.reserve(n);
+
+    for (size_t i = 0; i < n; ++i) {
+      const size_t idx = (bufferIndex + PRESSURE_BUFFER_SIZE - n + i) % PRESSURE_BUFFER_SIZE;
+      tmp.push_back(pressureKPABuffer[idx]);
+    }
+
+    const float low_pct = 0.05f;
+    const float high_pct = 0.95f;
+    const size_t idxLow  = static_cast<size_t>(floorf(low_pct * (n - 1)));
+    const size_t idxHigh = static_cast<size_t>(floorf(high_pct * (n - 1)));
+
+    std::nth_element(tmp.begin(), tmp.begin() + idxLow, tmp.end());
+    const float lowVal = tmp[idxLow];
+
+    std::nth_element(tmp.begin(), tmp.begin() + idxHigh, tmp.end());
+    const float highVal = tmp[idxHigh];
+
+    return (highVal > lowVal) ? (highVal - lowVal) : 0.0f;
+}
+
 float SensorManager::readOscillationAmplitude() {
     return amplitudeOscillation;
+}
+
+void SensorManager::resetPressureMetrics() {
+    pressureCount = 0;
+    bufferIndex = 0;
+    amplitudeOscillation = 0.0f;
+    pressureMedianKPa = 0.0f;
+    pressureMadKPa = 0.0f;
+    pressureOutlierRatio = 0.0f;
+    pressureRmsSlope = 0.0f;
+    lastPressureRms = 0.0f;
+    lastPressureRmsMs = 0;
 }
 
  // Tau: tiempo de decaimiento de picos (>37% del valor máximo del pico)

--- a/lib/sensors/SensorManager.h
+++ b/lib/sensors/SensorManager.h
@@ -55,7 +55,9 @@ public:
   float getPressurePercentAbs();
   float getPressurePSI();
   float computeOscillationAmplitude();  
+  float computeOscillationAmplitudeWindow(uint32_t windowMs, float samplePeriodMs = 12.5f) const;
   float readOscillationAmplitude(); 
+  void resetPressureMetrics();
   float getPressureMedianKPa() const { return pressureMedianKPa; }
   float getPressureMADKPa() const { return pressureMadKPa; }
   float getPressureOutlierRatio() const { return pressureOutlierRatio; }


### PR DESCRIPTION
### Motivation
- Reduce false positives and unstable winners in the resonance mapping by making measurements robust to transient spikes and noise. 
- Make mapping behavior observable and less sensitive to single-shot reads so mapped results are repeatable in real vehicles.

### Description
- Added repeated-sample infrastructure and scoring: `kRepeatCount`, `RepeatStats`, `measureMedianWithRepeats(...)` and a tiny in-file `sortSmall(...)` sorter to compute median/min/max from multiple runs instead of single-shot reads, and switched scoring to use median values. (changes to `ResonanceCalibrationService.h` / `ResonanceCalibrationService.cpp`).
- Penalize noisy candidates with `kRepeatSpreadPenalty` by subtracting a spread-based term from the raw improvement to avoid promoting unstable peaks. (injection/test scoring logic updated).
- Added a confirmation pass `confirmBestCandidateInBin(...)` (using `kConfirmRepeatCount`) that re-tests the chosen best candidate per bin and demotes it to `NONE` if it does not confirm minimum improvement. (integrated into the per-bin flow and time estimate).
- Improved runtime behavior: implemented `ensureStableInBin(...)`, `waitForMafRiseAfterBaseline(...)`, updated `estimateBinTestTimeMs()` to include repeats/confirmation and increased sample sizing (`kAmpCount`, `kAmpLevels`, `kBinCount`, sample durations) for more robust sensing.
- Sensor-side changes: added `resetPressureMetrics()` and `computeOscillationAmplitudeWindow(...)` and wired `sampleMetric(...)` to reset metrics and use the windowed amplitude computation to isolate each measurement. (changes to `SensorManager.h` / `SensorManager.cpp`).

### Testing
- Attempted build with `platformio run`, which failed in this environment because `platformio` is not installed (`command not found`).
- No automated unit tests were available or executed in this environment; changes were validated via static inspection and local runtime checks (search/grep) and committed to the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb91ef9f48326825e0360530e8835)