### PR TITLE
Add two-layer vortex control (passive + full) and AFR design document

### DIFF
--- a/BOOST_AFR_DESIGN.md
+++ b/BOOST_AFR_DESIGN.md
@@ -1,0 +1,171 @@
+# Diseño v2 (simplificado): Vortex en 2 capas + gate AFR futuro
+
+> Este documento reemplaza la versión anterior.
+> Objetivo: definir una lógica simple, precisa y aplicable para el vortex, manteniendo la semántica actual de la FSM (`ALIGN`, `FLOW`, `DECAY`) y sin dependencia de BEAM.
+
+---
+
+## 1) Objetivo principal
+
+Sostener rendimiento de admisión en motor atmosférico con dos capas de actuación del vortex:
+
+1. **Capa pasiva** de asistencia de flujo (bajas/medias RPM) gobernada por demanda de vacío.
+2. **Capa full progresiva** al detectar demanda sostenida de vacío y MAF en zona alta (`>= 0.80`) durante un tiempo mínimo.
+
+No se evalúa caída de MAF en esta versión.
+
+---
+
+## 2) Principios de diseño (reglas duras)
+
+1. **Sin nuevos estados en FSM**: `ALIGN/FLOW/DECAY` mantienen su significado.
+2. **Sin dependencia de BEAM** para activar vortex.
+3. **Base por vacío**: la intención de potencia la determina el vacío.
+4. **Disparo por umbral MAF alto + tiempo** (no por caída de MAF).
+5. **Salida de full solo por liberación de vacío** (el conductor dejó de pedir potencia).
+6. **AFR se agrega como gate en fase posterior**.
+
+---
+
+## 3) Arquitectura funcional de 2 capas
+
+### 3.1 Capa 1 — Passive Assist
+- Activa cuando hay demanda de vacío.
+- Entrega comando suave de vortex para favorecer corriente/laminaridad.
+- No busca 100% PWM.
+
+### 3.2 Capa 2 — Full Progressive
+- Entra cuando:
+  - vacío en demanda sostenida,
+  - `maf_norm >= MAF_NEAR_MAX_TH`,
+  - condición sostenida por `HOLD_MS`.
+- Una vez activa, sube el comando a `100%` con rampa progresiva.
+- Sale cuando el vacío indique fin de demanda.
+
+---
+
+## 4) Señales de entrada (conceptuales)
+
+- `pressure_pct_signed` (vacío firmado, negativo en vacío)
+- `maf_norm` (MAF normalizado 0..1)
+- `base_boost_cmd` (comando base actual, 0..1)
+- Futuro:
+  - `afr_value`
+  - `afr_valid`
+
+---
+
+## 5) Lógica simplificada
+
+## 5.1 Detección de demanda por vacío
+
+Con histéresis:
+- `vacuum_demand_on` si `pressure_pct_signed <= VACUUM_PCT_ON`
+- `vacuum_demand_off` si `pressure_pct_signed >= VACUUM_PCT_OFF`
+
+(Usar ventana breve para estabilidad de señal, evitando rebotes instantáneos.)
+
+### 5.2 Umbral alto de MAF
+
+- `maf_high = (maf_norm >= MAF_NEAR_MAX_TH)`
+- Valor inicial acordado: `MAF_NEAR_MAX_TH = 0.80`
+
+### 5.3 Activación Full
+
+Activar full progresivo si:
+
+```text
+vacuum_demand_on && maf_high sostenidos por HOLD_MS
+```
+
+### 5.4 Sostén y salida
+
+- Mientras `vacuum_demand_on` permanezca activo, mantener full.
+- Salir de full cuando se cumpla `vacuum_demand_off`.
+
+No hay condición por caída de MAF en esta versión.
+
+---
+
+## 6) Pseudoflujo de control
+
+```text
+if !vacuum_demand_on:
+    mode = IDLE/PASSIVE_OFF
+else:
+    mode = PASSIVE_ASSIST
+
+if vacuum_demand_on && maf_norm >= 0.80 durante HOLD_MS:
+    mode = FULL_PROGRESSIVE
+
+if mode == FULL_PROGRESSIVE && vacuum_demand_off:
+    salir de FULL (rampa de retorno)
+```
+
+---
+
+## 7) Parámetros iniciales (calibrables)
+
+- `VACUUM_PCT_ON = -2.0`
+- `VACUUM_PCT_OFF = -0.5`
+- `MAF_NEAR_MAX_TH = 0.80`
+- `HOLD_MS = 120`
+- `FULL_TARGET = 1.00` (100%)
+- `FULL_RAMP_UP_MS` (definir en pruebas)
+- `FULL_RAMP_DOWN_MS` (definir en pruebas)
+
+---
+
+## 8) AFR gate (fase posterior)
+
+Se aplicará solo cuando exista sensor AFR válido.
+
+Política acordada:
+- **Habilitación de sistema** cuando `AFR < 13.5`.
+- **Corte/retiro de full** cuando `AFR < 12.0` (mezcla rica de protección).
+
+Nota: mientras no exista señal AFR confiable, la lógica opera solo con vacío + MAF.
+
+---
+
+## 9) Integración sin romper arquitectura
+
+1. Mantener la FSM actual y su semántica.
+2. Ejecutar esta lógica como capa de arbitraje de comando de vortex en `ALIGN/FLOW`.
+3. En `DECAY/IDLE/OFF`, reset de banderas internas de esta capa.
+4. Mantener responsabilidades:
+   - FSM decide contexto de estado.
+   - capa vortex decide nivel objetivo (pasivo/full).
+   - `VortexController` aplica PWM con suavizado/rampa.
+
+---
+
+## 10) Telemetría mínima recomendada
+
+- `vacuum_demand_on/off`
+- `maf_norm`
+- `maf_high`
+- `full_armed`
+- `full_active`
+- `hold_elapsed_ms`
+- `boost_cmd_out`
+- Futuro: `afr_valid`, `afr_value`, `afr_gate_state`
+
+---
+
+## 11) Criterios de aceptación
+
+1. En demanda baja/media: funciona capa pasiva sin entrar a full.
+2. Con vacío sostenido + `maf_norm >= 0.80` por `120 ms`: entra full progresivo.
+3. Full se mantiene mientras exista demanda de vacío.
+4. Full se desactiva al liberar demanda (vacío off).
+5. No se agregan estados FSM nuevos.
+6. Cuando se integre AFR:
+   - habilita bajo `<13.5`
+   - corta bajo `<12.0`
+
+---
+
+## 12) Frase de intención
+
+Extender el vortex para sostener rendimiento de admisión con una lógica simple y precisa (vacío + umbral MAF + tiempo), preservando la semántica de `ALIGN/FLOW` y dejando AFR como gate de seguridad en fase posterior.

--- a/lib/core/StateMachine.cpp
+++ b/lib/core/StateMachine.cpp
@@ -60,6 +60,7 @@ void StateMachine::begin(bool hasCalibration,
         actuators->stopAcoustic();
         actuators->stopVortex();
     }
+    resetVortexTwoLayerState();
 
     lastState = current;
     Serial.print(">> StateMachine iniciado en estado: ");
@@ -218,6 +219,7 @@ void StateMachine::update(float mapLoadPercent,
                 actuators->stopAcoustic();
                 actuators->stopVortex();
             }
+            resetVortexTwoLayerState();
             _flowStableStartMs = 0;
             _flowUnstableStartMs = 0;
         } else if (current == SystemState::ALIGN) {
@@ -236,6 +238,7 @@ void StateMachine::update(float mapLoadPercent,
                 flowBoostBase = actuators->getTurboLevel();
             }
         } else if (current == SystemState::DECAY && actuators) {
+            resetVortexTwoLayerState();
             resetBeamTracking();
             float deriv = _dMAFdtEMA;
             unsigned long holdMs = 0;
@@ -357,14 +360,15 @@ void StateMachine::handleActions() {
         lastDeltaMAFLevelForBEAM = currentDeltaMAFLevelForBEAM;
         lastDeltaMAPLevelForBEAM = currentDeltaMAPLevelForBEAM;
 
-        actuators->updateVortexLevel(alignBoostLevel, alignBoostLevel);
+        float vortexCmd = computeVortexTwoLayerCmd(millis(), mafNormalized, _pressurePercent);
+        actuators->updateVortexLevel(vortexCmd, vortexCmd);
         actuators->updateInjector();
     }
 
     if (current == SystemState::FLOW) {
         float scale = constrain(mafNormalized, 0.0f, 1.0f);
         float acousticLevel = constrain(flowAcousticBase * scale, 0.0f, 1.0f);
-        float boostLevel = constrain(flowBoostBase * scale, 0.0f, 1.0f);
+        float boostLevel = computeVortexTwoLayerCmd(millis(), scale, _pressurePercent);
         actuators->setAcousticParameters(acousticLevel, acousticLevel);
         actuators->updateVortexLevel(boostLevel, boostLevel);
         actuators->updateInjector();
@@ -394,6 +398,52 @@ void StateMachine::resetBeamTracking() {
   _holdStartMillis = 0;
   _beamVortexLevel = BEAM_VORTEX_ENTRY_LEVEL;
   _beamVortexLastUpdateMs = 0;
+}
+
+void StateMachine::resetVortexTwoLayerState() {
+  _vortexFullActive = false;
+  _vortexFullCondStartMs = 0;
+  _vortexCmd = 0.0f;
+}
+
+float StateMachine::computeVortexTwoLayerCmd(uint32_t nowMs, float mafNorm, float pressurePctSigned) {
+  constexpr float MAF_NEAR_MAX_TH = 0.80f;
+  constexpr uint32_t HOLD_MS = 120u;
+  constexpr float FULL_TARGET = 1.0f;
+  constexpr float PASSIVE_MAX = 0.45f;
+  constexpr float FULL_RAMP_UP_ALPHA = 0.22f;
+  constexpr float FULL_RAMP_DOWN_ALPHA = 0.12f;
+
+  bool vacuumDemandOn = (pressurePctSigned <= VACUUM_PCT_ON);
+  bool vacuumDemandOff = (pressurePctSigned >= VACUUM_PCT_OFF);
+
+  float vacuumNorm = 0.0f;
+  if (pressurePctSigned < 0.0f) {
+    vacuumNorm = constrain((-pressurePctSigned) / 20.0f, 0.0f, 1.0f);
+  }
+  float passiveCmd = vacuumNorm * PASSIVE_MAX;
+
+  bool mafHigh = (mafNorm >= MAF_NEAR_MAX_TH);
+  bool fullCond = vacuumDemandOn && mafHigh;
+
+  if (fullCond) {
+    if (_vortexFullCondStartMs == 0) _vortexFullCondStartMs = nowMs;
+    if ((nowMs - _vortexFullCondStartMs) >= HOLD_MS) {
+      _vortexFullActive = true;
+    }
+  } else {
+    _vortexFullCondStartMs = 0;
+  }
+
+  if (_vortexFullActive && vacuumDemandOff) {
+    _vortexFullActive = false;
+  }
+
+  float target = _vortexFullActive ? FULL_TARGET : passiveCmd;
+  float alpha = _vortexFullActive ? FULL_RAMP_UP_ALPHA : FULL_RAMP_DOWN_ALPHA;
+  _vortexCmd += (target - _vortexCmd) * alpha;
+  _vortexCmd = constrain(_vortexCmd, 0.0f, 1.0f);
+  return _vortexCmd;
 }
 
 float StateMachine::updateBeamVortexRamp(float mafPower) {

--- a/lib/core/StateMachine.h
+++ b/lib/core/StateMachine.h
@@ -263,9 +263,14 @@ private:
   // Seguimiento de la condición BEAM sostenida
   uint32_t _beamCondStartMs = 0;   // instante en que se detecto la condicion por primera vez
   uint32_t _beamStreamStartMs = 0;
+  bool _vortexFullActive = false;
+  uint32_t _vortexFullCondStartMs = 0;
+  float _vortexCmd = 0.0f;
 
 
     void resetBeamVortexRamp(float seedLevel);
     float updateBeamVortexRamp(float mafPower);
+    float computeVortexTwoLayerCmd(uint32_t nowMs, float mafNorm, float pressurePctSigned);
+    void resetVortexTwoLayerState();
 
 };


### PR DESCRIPTION
### Motivation

- Introduce a simple, deterministic two-layer vortex control to sustain intake performance using vacuum + MAF threshold while preserving existing FSM semantics (`ALIGN`, `FLOW`, `DECAY`).
- Provide a reference design for future AFR gating and integration as a safety gate.

### Description

- Add `BOOST_AFR_DESIGN.md` with the simplified v2 architecture, design rules, parameters, and AFR gating policy. 
- Implement two-layer vortex control in `StateMachine`: add members `_vortexFullActive`, `_vortexFullCondStartMs`, and `_vortexCmd` and expose `computeVortexTwoLayerCmd` and `resetVortexTwoLayerState` in the header.
- Integrate the new logic into lifecycle and action paths by calling `resetVortexTwoLayerState()` at appropriate state transitions and replacing direct vortex updates with `computeVortexTwoLayerCmd(...)` in `handleActions()` and `FLOW` handling.
- Implement `computeVortexTwoLayerCmd` which implements vacuum-based passive assist, MAF-thresholded full progressive entry after a hold time, ramping behavior, and full exit on vacuum release using local configurable constants.

### Testing

- Project compiled successfully after the changes (`StateMachine` builds and links with new functions). 
- Existing automated unit tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf2e096a0832684819f501e54d259)